### PR TITLE
ce-507: attempt to fix uid/gid of files created in /home/cumulus

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,7 @@ do
         if [ ! -e pkgs/$REPO/$PKG/debian/DEBIAN/control ]; then
             echo "** WARNING ** skipping $REPO/$PKG no control file"
         else
-            if ! dpkg-deb --build pkgs/$REPO/$PKG/debian repo-build/$REPO/binary-amd64/${PKG}_amd64.deb
+            if ! fakeroot dpkg-deb --build pkgs/$REPO/$PKG/debian repo-build/$REPO/binary-amd64/${PKG}_amd64.deb
             then
                 echo "** ERROR ** while building $REPO/$PKG"
                 exit 1

--- a/pkgs/workbench/cldemo-wbench-base-ansible/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-base-ansible/debian/DEBIAN/postinst
@@ -11,4 +11,6 @@ fi
 cp -f /var/www/topology.dot /home/cumulus/ansibledemos/roles/common/files
 cp -f /var/www/*.lic /home/cumulus/ansibledemos/roles/common/files
 
+chown -R cumulus:cumulus /home/cumulus/
+
 exit 0

--- a/pkgs/workbench/cldemo-wbench-base/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-base/debian/DEBIAN/postinst
@@ -15,4 +15,6 @@ set -e
 ln -fs /usr/local/cumulus/bin/cw-mux /usr/local/bin/cw-mux
 ln -fs /usr/local/cumulus/bin/cw-mux-helper /usr/local/bin/cw-mux-helper
 
+chown -R cumulus:cumulus /home/cumulus/
+
 exit 0

--- a/pkgs/workbench/cldemo-wbench-hortonworks-2lt22s-ansible/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-hortonworks-2lt22s-ansible/debian/DEBIAN/postinst
@@ -7,4 +7,6 @@ cw-pxehelper -o ubuntuserver-trusty -s server2 -n
 # restart the switches, so they grab the SSH key
 cw-swpower -o reset -a
 
+chown -R cumulus:cumulus /home/cumulus/
+
 exit 0

--- a/pkgs/workbench/cldemo-wbench-ibgp-2s-ansible/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-ibgp-2s-ansible/debian/DEBIAN/postinst
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# set /home/cumulus files to use cumulus:cumulus ownership
+chown -R cumulus:cumulus /home/cumulus
+
+exit 0

--- a/pkgs/workbench/cldemo-wbench-ibgp-2s2l-ansible/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-ibgp-2s2l-ansible/debian/DEBIAN/postinst
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# set /home/cumulus files to use cumulus:cumulus ownership
+chown -R cumulus:cumulus /home/cumulus
+
+exit 0

--- a/pkgs/workbench/cldemo-wbench-ibgp-base-ansible/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-ibgp-base-ansible/debian/DEBIAN/postinst
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# set /home/cumulus files to use cumulus:cumulus ownership
+chown -R cumulus:cumulus /home/cumulus
+
+exit 0

--- a/pkgs/workbench/cldemo-wbench-osinstaller-ubuntuserver/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-osinstaller-ubuntuserver/debian/DEBIAN/postinst
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# set /home/cumulus files to use cumulus:cumulus ownership
+chown -R cumulus:cumulus /home/cumulus
+
+exit 0

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-ansible/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-ansible/debian/DEBIAN/postinst
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# set /home/cumulus files to use cumulus:cumulus ownership
+chown -R cumulus:cumulus /home/cumulus
+
+exit 0

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2s-ansible/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2s-ansible/debian/DEBIAN/postinst
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# set /home/cumulus files to use cumulus:cumulus ownership
+chown -R cumulus:cumulus /home/cumulus
+
+exit 0

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2s2l-ansible/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2s2l-ansible/debian/DEBIAN/postinst
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# set /home/cumulus files to use cumulus:cumulus ownership
+chown -R cumulus:cumulus /home/cumulus
+
+exit 0

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-base-ansible/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-base-ansible/debian/DEBIAN/postinst
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# set /home/cumulus files to use cumulus:cumulus ownership
+chown -R cumulus:cumulus /home/cumulus
+
+exit 0


### PR DESCRIPTION
here is the script I used to update the postinst scripts
```
#!/usr/bin/env bash

dirlist=`find -name "*DEBIAN"`
homebase=`pwd`
for entry in $dirlist; do
  fullpath="${homebase}/${entry}"
  cd "$fullpath"
  cd ..
  has_home_cumulus=`find -type d -name '*cumulus'`
  if [ "$has_home_cumulus" != "" ]; then
    postinst="${fullpath}/postinst"
    if [ ! -e $postinst ]; then
      echo "$entry - postinst does not exist"
      cat > $postinst << EOF
#!/usr/bin/env bash

# set /home/cumulus files to use cumulus:cumulus ownership
chown -R cumulus:cumulus /home/cumulus

exit 0
EOF
      chmod 755 $postinst
    elif ! grep -q chown $postinst ; then
      echo "$entry - chown not in postinst"
      sed -i s/"exit 0"/"chown -R cumulus:cumulus \/home\/cumulus\/\n\nexit 0"/ $postinst
      chmod 755 $postinst
    else
      echo "$entry - exists"
    fi
  fi
done

```