### PR TITLE
CE-453: Change cw-mux ordering

### DIFF
--- a/pkgs/workbench/cldemo-wbench-base/debian/usr/local/cumulus/bin/cw-mux
+++ b/pkgs/workbench/cldemo-wbench-base/debian/usr/local/cumulus/bin/cw-mux
@@ -149,10 +149,11 @@ then
              tmux split-window -d -t 0 -v
              tmux split-window -d -t 0 -h
              tmux split-window -d -t 2 -h
+             tmux select-layout tiled
              tmux send-keys -t 0 "cw-mux-helper $MUXTYPE spine1" 'C-m'
-             tmux send-keys -t 1 "cw-mux-helper $MUXTYPE leaf2" 'C-m'
-             tmux send-keys -t 2 "cw-mux-helper $MUXTYPE spine2" 'C-m'
-             tmux send-keys -t 3 "cw-mux-helper $MUXTYPE leaf1" 'C-m'
+             tmux send-keys -t 1 "cw-mux-helper $MUXTYPE spine2" 'C-m'
+             tmux send-keys -t 2 "cw-mux-helper $MUXTYPE leaf1" 'C-m'
+             tmux send-keys -t 3 "cw-mux-helper $MUXTYPE leaf2" 'C-m'
         else
             echo "Unusual number of switches"
         fi


### PR DESCRIPTION
The problem is that the pane numbers (C-b q) get messed up when doing the window splits. First we split the window into four panes, then apply the tiled layout so that they are numbered in the expected order.