### PR TITLE
CE-471

### DIFF
--- a/pkgs/workbench/cldemo-wbench-base-chef/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-base-chef/debian/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: cldemo-wbench-base-chef
-Version: 0.3-0
+Version: 0.4-0
 Section: base
 Priority: optional
 Architecture: all

--- a/pkgs/workbench/cldemo-wbench-base-chef/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-base-chef/debian/DEBIAN/postinst
@@ -13,6 +13,7 @@ sleep 5
 pushd /usr/local/share/chef
 	knife cookbook upload sysctl 
 	knife cookbook upload cldemo_base
+	knife cookbook upload portsconf
 	knife role from file roles/switch.json
 
 	# Load Data Bags

--- a/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/README.md
+++ b/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/README.md
@@ -1,0 +1,68 @@
+foo Cookbook
+============
+TODO: Enter the cookbook description here.
+
+e.g.
+This cookbook makes your favorite breakfast sandwich.
+
+Requirements
+------------
+TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+e.g.
+#### packages
+- `toaster` - foo needs toaster to brown your bagel.
+
+Attributes
+----------
+TODO: List your cookbook attributes here.
+
+e.g.
+#### foo::default
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['foo']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
+Usage
+-----
+#### foo::default
+TODO: Write usage instructions for each cookbook.
+
+e.g.
+Just include `foo` in your node's `run_list`:
+
+```json
+{
+  "name":"my_node",
+  "run_list": [
+    "recipe[foo]"
+  ]
+}
+```
+
+Contributing
+------------
+TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+e.g.
+1. Fork the repository on Github
+2. Create a named feature branch (like `add_component_x`)
+3. Write your change
+4. Write tests for your change (if applicable)
+5. Run the tests, ensuring they all pass
+6. Submit a Pull Request using Github
+
+License and Authors
+-------------------
+Authors: TODO: List authors

--- a/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/files/default/40G.conf
+++ b/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/files/default/40G.conf
@@ -6,7 +6,7 @@
 #
 #   configure port speed, aggregation, and subdivision.
 #
-# The Celestica Smallstone has:
+# The switches have:
 #     32 QSFP ports numbered 1-32
 #     These ports are configurable as 40G or split into 4x10G ports.
 #

--- a/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/files/default/40G.conf
+++ b/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/files/default/40G.conf
@@ -1,0 +1,58 @@
+#
+# maintained by chef
+#
+
+# ports.conf --
+#
+#   configure port speed, aggregation, and subdivision.
+#
+# The Celestica Smallstone has:
+#     32 QSFP ports numbered 1-32
+#     These ports are configurable as 40G or split into 4x10G ports.
+#
+#     The X pipeline covers QSFP ports 1 through 16 and the Y pipeline
+#     covers QSFP ports 17 through 32.
+#
+#     The Trident2 chip can only handle 52 logical ports per pipeline.
+#
+#     This means 12 is the maximum number of 40G ports you can ungang
+#     per pipeline. The 12 40G ports become 48 unganged 10G ports,
+#     plus the remaining 4 40G ports totals 52 logical ports for that
+#     pipeline.
+#
+
+# QSFP+ ports
+#
+# <port label 1-32> = [4x10G|40G]
+1=4x10G
+2=40G
+3=40G
+4=40G
+5=40G
+6=40G
+7=40G
+8=40G
+9=40G
+10=40G
+11=40G
+12=40G
+13=40G
+14=40G
+15=40G
+16=40G
+17=40G
+18=40G
+19=40G
+20=40G
+21=40G
+22=40G
+23=40G
+24=40G
+25=40G
+26=40G
+27=40G
+28=40G
+29=40G
+30=40G
+31=40G
+32=4x10G

--- a/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/metadata.rb
+++ b/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/metadata.rb
@@ -1,0 +1,7 @@
+name             'portsconf'
+maintainer       'Cumulus Networks'
+maintainer_email 'YOUR_EMAIL'
+license          'All rights reserved'
+description      'Configures ports on T2 switches'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/recipes/default.rb
+++ b/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/recipes/default.rb
@@ -1,0 +1,8 @@
+#
+# Cookbook Name:: portsconf
+# Recipe:: default
+#
+# Copyright 2015, Cumulus Networks
+#
+# All rights reserved - Do Not Redistribute
+#

--- a/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/recipes/forty_gbe.rb
+++ b/pkgs/workbench/cldemo-wbench-base-chef/debian/usr/local/share/chef/cookbooks/portsconf/recipes/forty_gbe.rb
@@ -1,0 +1,17 @@
+#
+# Cookbook Name:: portsconf
+# Recipe:: default
+#
+# Copyright 2015, Cumulus Networks
+#
+# All rights reserved - Do Not Redistribute
+#
+
+cookbook_file '40G.conf' do
+  path '/etc/cumulus/ports.conf'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+  notifies :restart, "service[switchd]"
+end

--- a/pkgs/workbench/cldemo-wbench-base-puppet/debian/etc/puppet/modules/portsconf/files/40G.conf
+++ b/pkgs/workbench/cldemo-wbench-base-puppet/debian/etc/puppet/modules/portsconf/files/40G.conf
@@ -6,7 +6,7 @@
 #
 #   configure port speed, aggregation, and subdivision.
 #
-# The Celestica Smallstone has:
+# The switches have:
 #     32 QSFP ports numbered 1-32
 #     These ports are configurable as 40G or split into 4x10G ports.
 #

--- a/pkgs/workbench/cldemo-wbench-openstack-2lt22s-puppet/debian/etc/puppet/modules/openstack/files/40G.conf
+++ b/pkgs/workbench/cldemo-wbench-openstack-2lt22s-puppet/debian/etc/puppet/modules/openstack/files/40G.conf
@@ -6,7 +6,7 @@
 #
 #   configure port speed, aggregation, and subdivision.
 #
-# The Celestica Smallstone has:
+# The switches have:
 #     32 QSFP ports numbered 1-32
 #     These ports are configurable as 40G or split into 4x10G ports.
 #

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/DEBIAN/control
@@ -1,0 +1,9 @@
+Package: cldemo-wbench-ospfunnum-2lt22s-chef
+Version: 0.1
+Section: base
+Priority: optional
+Architecture: all
+Depends: cldemo-wbench-ospfunnum-base-chef
+Maintainer: Kristian Van Der Vliet <kristian@cumulusnetworks.com>
+Description: 2 (T2) leaf 2 spine; Chef, PTM and OSPF Unnumbered IPv4
+  4 switch lab, managed by Chef, OSPF Unnumbered IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/DEBIAN/postinst
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/DEBIAN/postinst
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+pushd /usr/local/share/chef
+	knife node from file nodes/leaf1.json
+	knife node from file nodes/leaf2.json
+	knife node from file nodes/spine1.json
+	knife node from file nodes/spine2.json
+
+	pushd data_bags
+		knife data bag from file interfaces interfaces
+	popd
+
+exit 0
+

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/data_bags/interfaces/leaf1.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/data_bags/interfaces/leaf1.json
@@ -1,0 +1,18 @@
+{
+	"id": "leaf1",
+	"loopback": { "address": "10.2.1.1" },
+	"unnumbered": [ "swp1s0", "swp1s1", "swp1s2", "swp1s3" ],
+	"bridges": [
+	{
+		"name": "br0",
+		"address": "10.4.1.1",
+		"netmask": "255.255.255.128",
+    "ports": [ "swp32s0" ]
+	},
+	{
+		"name": "br1",
+		"address": "10.4.1.129",
+		"netmask": "255.255.255.128",
+    "ports": [ "swp32s1" ]
+	}]
+}

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/data_bags/interfaces/leaf2.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/data_bags/interfaces/leaf2.json
@@ -1,0 +1,19 @@
+{
+  "id": "leaf2",
+  "loopback": { "address": "10.2.1.2" },
+  "unnumbered": [ "swp1s0","swp1s1","swp1s2","swp1s3" ],
+  "bridges": [
+   {
+    "name": "br0",
+    "address": "10.4.2.1",
+    "netmask": "255.255.255.128",
+    "ports": [ "swp32s0" ]
+   },
+   {
+    "name": "br1",
+    "address": "10.4.2.129",
+    "netmask": "255.255.255.128",
+    "ports": [ "swp32s1" ]
+   }
+  ]
+}

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/data_bags/interfaces/spine1.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/data_bags/interfaces/spine1.json
@@ -1,0 +1,6 @@
+{
+	"id": "spine1",
+	"loopback": { "address": "10.2.1.3" },
+	"unnumbered": [ "swp49", "swp50", "swp51", "swp52" ],
+	"bridges": []
+}

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/data_bags/interfaces/spine2.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/data_bags/interfaces/spine2.json
@@ -1,0 +1,6 @@
+{
+	"id": "spine2",
+	"loopback": { "address": "10.2.1.4" },
+	"unnumbered": [ "swp49", "swp50", "swp51", "swp52" ],
+	"bridges": []
+}

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf1.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf1.json
@@ -6,5 +6,5 @@
 
     ]
   },
-  "run_list": ["role[switch]","recipe[cldemo_ospf_unnumbered]","recipe[portsconf::forty_gbe]"]
+  "run_list": ["role[switch]","recipe[portsconf::forty_gbe]","recipe[cldemo_ospf_unnumbered]"]
 }

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf1.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf1.json
@@ -6,5 +6,5 @@
 
     ]
   },
-  "run_list": ["role[switch]","recipe[cldemo_ospf_unnumbered]"]
+  "run_list": ["role[switch]","recipe[cldemo_ospf_unnumbered]","recipe[portsconf::forty_gbe]"]
 }

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf1.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf1.json
@@ -1,0 +1,10 @@
+{
+  "name": "leaf1",
+  "chef_environment": "_default",
+  "normal": {
+    "tags": [
+
+    ]
+  },
+  "run_list": ["role[switch]","recipe[cldemo_ospf_unnumbered]"]
+}

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf2.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf2.json
@@ -6,5 +6,5 @@
 
     ]
   },
-  "run_list": ["role[switch]","recipe[cldemo_ospf_unnumbered]","recipe[portsconf::forty_gbe]"]
+  "run_list": ["role[switch]","recipe[portsconf::forty_gbe]","recipe[cldemo_ospf_unnumbered]"]
 }

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf2.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf2.json
@@ -1,0 +1,10 @@
+{
+  "name": "leaf2",
+  "chef_environment": "_default",
+  "normal": {
+    "tags": [
+
+    ]
+  },
+  "run_list": ["role[switch]","recipe[cldemo_ospf_unnumbered]"]
+}

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf2.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/leaf2.json
@@ -6,5 +6,5 @@
 
     ]
   },
-  "run_list": ["role[switch]","recipe[cldemo_ospf_unnumbered]"]
+  "run_list": ["role[switch]","recipe[cldemo_ospf_unnumbered]","recipe[portsconf::forty_gbe]"]
 }

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/spine1.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/spine1.json
@@ -1,0 +1,10 @@
+{
+  "name": "spine1",
+  "chef_environment": "_default",
+  "normal": {
+    "tags": [
+
+    ]
+  },
+  "run_list": ["role[switch]","recipe[cldemo_ospf_unnumbered]"]
+}

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/spine2.json
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/usr/local/share/chef/nodes/spine2.json
@@ -1,0 +1,10 @@
+{
+  "name": "spine2",
+  "chef_environment": "_default",
+  "normal": {
+    "tags": [
+
+    ]
+  },
+  "run_list": ["role[switch]","recipe[cldemo_ospf_unnumbered]"]
+}


### PR DESCRIPTION
Add OSPF Unnumbered with Chef for 2lt22s topology.
Adds the "portsconf" Cookbook to base-chef which has the same function as the Ansible & Puppet demos; only the forty_gbe recipe does anything.
Tested manually on a workbench as we currently have no usable tests for 2lt22s ospfunnum; see CE-426