### PR TITLE
fixing openstack problem

### DIFF
--- a/pkgs/workbench/cldemo-wbench-openstack-2lt22s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-openstack-2lt22s-puppet/debian/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: cldemo-wbench-openstack-2lt22s-puppet
-Version: 0.1-8
+Version: 0.2-0
 Section: base
 Priority: optional
 Architecture: all

--- a/pkgs/workbench/cldemo-wbench-openstack-2lt22s-puppet/debian/etc/puppet/modules/openstack/manifests/interfaces.pp
+++ b/pkgs/workbench/cldemo-wbench-openstack-2lt22s-puppet/debian/etc/puppet/modules/openstack/manifests/interfaces.pp
@@ -25,9 +25,8 @@ class openstack::interfaces {
         }
 
     exec { '/sbin/ifup bond0':
-        onlyif    => "/usr/bin/test ! -e /proc/net/bonding/bond0",
         logoutput => on_failure,
-        require   => File['/etc/network/interfaces/']
+        require   => Exec['/sbin/ip link set dev eth2 up; /sbin/ip link set dev eth3 up']
         }
 
   }


### PR DESCRIPTION
root cause is that sometimes the bond0 on ubuntu would not come up,
however it would exist in /proc/net/bonding/bond0