### PR TITLE
replace maintainer field in debian/control with customer engineering.

### DIFF
--- a/pkgs/switch/cldemo-switch-billboard/debian/DEBIAN/control
+++ b/pkgs/switch/cldemo-switch-billboard/debian/DEBIAN/control
@@ -3,6 +3,6 @@ Version: 0.1-1
 Section: base
 Priority: optional
 Architecture: all
-Maintainer: Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Billboard of looped commands
   Billboard of looped commands

--- a/pkgs/workbench/cldemo-wbench-aptmirror/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-aptmirror/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base ,apt-mirror
-Maintainer: Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Pre-configured apt-mirror of repo.cumulusnetworks.com
   Repo includes all Cumulus Linux packages for 1.5 and 2.0 branches for powerpc

--- a/pkgs/workbench/cldemo-wbench-base-ansible/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-base-ansible/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: ansible, cldemo-wbench-base, cldemo-wbench-ztp-ansible
-Maintainer: Nat Morris <nat@cumulusnetworks.com>, Stanley Karunditu <stanleyk@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Ansible basic configuration
   Setup ansible and generate SSH keys

--- a/pkgs/workbench/cldemo-wbench-base-chef/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-base-chef/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base, expect, chef-server, chef
-Maintainer: Matt Willsher <matt@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Chef Server basic configuration
   Setup the Chef server, add a user

--- a/pkgs/workbench/cldemo-wbench-base-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-base-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: puppetmaster, cldemo-wbench-base, cldemo-wbench-ztp-puppet, puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Puppetmaster basic configuration
   Setup the puppetmaster, fileserver, autosigning etc

--- a/pkgs/workbench/cldemo-wbench-base/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-base/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: tree, jq, zip, apache2, bind9, bind9-host, curl, isc-dhcp-server, tmux, vim, htop, ccze
-Maintainer: Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Workbench base, common package dependencies
   Handy things for all demos

--- a/pkgs/workbench/cldemo-wbench-ganglia-2lt22s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ganglia-2lt22s-puppet/debian/DEBIAN/control
@@ -5,6 +5,6 @@ Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ganglia-base-puppet
 Breaks: cldemo-wbench-ospfunnum-2lt22s-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 leaf 2 spine; Puppet, OSPF Unnumbered IPv4, and Ganglia
   4 switch lab, managed by Puppet, OSPF Unnumbered IPv4 and Ganglia monitoring

--- a/pkgs/workbench/cldemo-wbench-ganglia-2s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ganglia-2s-puppet/debian/DEBIAN/control
@@ -5,6 +5,6 @@ Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ganglia-base-puppet
 Breaks: cldemo-wbench-ospfunnum-2s2l-puppet, cldemo-wbench-ospfunnum-2s-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 switch; Puppet, OSPF Unnumbered IPv4, and Ganglia
   2 switch lab, managed by Puppet, OSPF Unnumbered IPv4 and Ganglia monitoring

--- a/pkgs/workbench/cldemo-wbench-ganglia-base-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ganglia-base-puppet/debian/DEBIAN/control
@@ -4,7 +4,7 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base-puppet, cldemo-wbench-ospfunnum-base-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Setup ganglia web frontend 
   Setup the ganglia web front end to display monitoring examples.
   Also includes ganglia-webfrontend 3.5.12

--- a/pkgs/workbench/cldemo-wbench-hortonworks-2lt22s-ansible/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-hortonworks-2lt22s-ansible/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base-ansible, cldemo-wbench-osinstaller-ubuntuserver-trusty, cldemo-wbench-ospfunnum-base-ansible
-Maintainer: Trapier Marshall <trapier@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Trident2 2 leaf 2 spine; Hosts running Hortonworks HDP
   4 switch lab with Hortonworks managed by Ansible

--- a/pkgs/workbench/cldemo-wbench-ibgp-2s-ansible/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ibgp-2s-ansible/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ibgp-base-ansible
-Maintainer: Nat Morris <nat@cumulusnetworks.com>, Stanley Karunditu <stanleyk@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 switch; Ansible, PTM and iBGP IPv4
   2 switch lab, managed by Ansible, iBGP IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ibgp-2s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ibgp-2s-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ibgp-base-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>, Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 leaf ; Puppet, PTM and iBGP IPv4
   2 switch lab, managed by Puppet, iBGP IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ibgp-2s2l-ansible/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ibgp-2s2l-ansible/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ibgp-base-ansible
-Maintainer: Nat Morris <nat@cumulusnetworks.com>, Stanley Karunditu <stanleyk@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 leaf 2 spine; Ansible, PTM and iBGP IPv4
   4 switch lab, managed by Ansible, iBGP IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ibgp-2s2l-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ibgp-2s2l-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ibgp-base-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 leaf 2 spine; Puppet, PTM and iBGP IPv4
   4 switch lab, managed by Puppet, iBGP IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ibgp-base-ansible/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ibgp-base-ansible/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base-ansible
-Maintainer: Nat Morris <nat@cumulusnetworks.com>, Stanley Karunditu <stanleyk@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Ansible, PTM and iBGP IPv4
   Ansible, iBGP IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ibgp-base-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ibgp-base-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Puppet, PTM and iBGP IPv4
   Puppet, iBGP IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ldap-1s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ldap-1s-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ldap-server-puppet,cldemo-wbench-ldap-client-puppet
-Maintainer: Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 1 switch LDAP client demonstration
   Sets LDAP entries so one switches uses LDAP for NSS and PAM.

--- a/pkgs/workbench/cldemo-wbench-ldap-client-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ldap-client-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base-puppet
-Maintainer: Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: LDAP client configured by Puppet
   Installs the modules and scripts to set up NSS and PAM LDAP clients

--- a/pkgs/workbench/cldemo-wbench-ldap-server-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ldap-server-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base-puppet
-Maintainer: Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: LDAP server configured by Puppet
   Sets up the workbench server as an LDAP server

--- a/pkgs/workbench/cldemo-wbench-librenms-2lt22s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-librenms-2lt22s-puppet/debian/DEBIAN/control
@@ -4,7 +4,7 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-librenms-base, cldemo-wbench-librenms-base-puppet, cldemo-wbench-openvpn
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com>, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Technology specific puppet configuration files for LibreNMS installation
   Files to allow puppet to configure the server and switches to use librenms
   Thank you to the Wikimedia Foundation for the basis of this module - 

--- a/pkgs/workbench/cldemo-wbench-librenms-2s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-librenms-2s-puppet/debian/DEBIAN/control
@@ -4,7 +4,7 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-librenms-base, cldemo-wbench-librenms-base-puppet, cldemo-wbench-openvpn
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com>, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Technology specific puppet configuration files for LibreNMS installation
   Files to allow puppet to configure the server and switches to use librenms
   Thank you to the Wikimedia Foundation for the basis of this module - 

--- a/pkgs/workbench/cldemo-wbench-librenms-base-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-librenms-base-puppet/debian/DEBIAN/control
@@ -4,7 +4,7 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-librenms-base, puppet, cldemo-wbench-base-puppet, cldemo-wbench-ospfunnum-base-puppet, snmp
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com>, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Puppet configuration files for LibreNMS installation
   Files to allow puppet to configure the server and switches to use librenms
   Thank you to the Wikimedia Foundation for the basis of this module - 

--- a/pkgs/workbench/cldemo-wbench-librenms-base/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-librenms-base/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com>, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Base files for LibreNMS installation
   Base files for LibreNMS installation, includes submodule of librenms

--- a/pkgs/workbench/cldemo-wbench-openstack-2lt22s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-openstack-2lt22s-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-openvpn, cldemo-wbench-base-puppet, cldemo-wbench-osinstaller-ubuntuserver-trusty-puppet, cldemo-wbench-ztp-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Openstack setup package for Puppet
   Tailored for the 2lt22s workbench setup

--- a/pkgs/workbench/cldemo-wbench-openvpn/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-openvpn/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: openvpn, cldemo-wbench-base
-Maintainer: Nat Morris <nat@cumulusnetworks.com>, Leslie Carr <leslie@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Pre-configured OpenVPN and TunnelBlick config
   Sets up preconfigured OpenVPN

--- a/pkgs/workbench/cldemo-wbench-osinstaller-erasembr/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-osinstaller-erasembr/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-tftpd
-Maintainer: Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Erase MBR on block devices on the booted server
     Simple bootable kernel and initrd to erase disk MBRs via PXE

--- a/pkgs/workbench/cldemo-wbench-osinstaller-ubuntuserver-precise/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-osinstaller-ubuntuserver-precise/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-osinstaller-ubuntuserver
-Maintainer: Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Installation of Ubuntu Server 12.04 onto servers
    Installation of Ubuntu Server 12.04 onto servers

--- a/pkgs/workbench/cldemo-wbench-osinstaller-ubuntuserver-trusty-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-osinstaller-ubuntuserver-trusty-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-osinstaller-ubuntuserver-trusty
-Maintainer: Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Installation of Ubuntu Server 14.04 with Puppet servers
    Installation of Ubuntu Server 14.04 onto servers with Puppet agent

--- a/pkgs/workbench/cldemo-wbench-osinstaller-ubuntuserver-trusty/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-osinstaller-ubuntuserver-trusty/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-osinstaller-ubuntuserver
-Maintainer: Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Installation of Ubuntu Server 14.04 onto servers
    Installation of Ubuntu Server 14.04 onto servers

--- a/pkgs/workbench/cldemo-wbench-osinstaller-ubuntuserver/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-osinstaller-ubuntuserver/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-tftpd, lftp
-Maintainer: Nat Morris <nat@cumulusnetworks.com>, Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Supporting tools for Ubuntu Linux operating system installation
    Supporting tools for Ubuntu Linux operating system installation

--- a/pkgs/workbench/cldemo-wbench-osinstaller-vmwareesxi55/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-osinstaller-vmwareesxi55/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-tftpd
-Maintainer: Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: OS installer for VMWare ESXi 5.5
     OS installer for VMWare ESXi 5.5 hypervisor, for physical and virtual hosts via PXE. Includes ovftool.

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-ansible/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-ansible/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ospfunnum-base-ansible
-Maintainer: Nat Morris <nat@cumulusnetworks.com>, Stanley Karunditu <stanleyk@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 (T2) leaf 2 spine; Ansible, PTM and OSPF Unnumbered IPv4
   4 switch lab, managed by Ansible, OSPF Unnumbered IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-chef/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ospfunnum-base-chef
-Maintainer: Kristian Van Der Vliet <kristian@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 (T2) leaf 2 spine; Chef, PTM and OSPF Unnumbered IPv4
   4 switch lab, managed by Chef, OSPF Unnumbered IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2lt22s-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ospfunnum-base-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Trident2 2 leaf 2 spine; Puppet, PTM and OSPF Unnumbered IPv4
   4 switch lab, managed by Puppet, OSPF Unnumbered IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2s-ansible/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2s-ansible/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ospfunnum-base-ansible
-Maintainer: Nat Morris <nat@cumulusnetworks.com>, Stanley Karunditu <stanleyk@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 switch; Ansible, PTM and OSPF Unnumbered IPv4
   2 switch lab, managed by Ansible, OSPF Unnumbered IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2s-chef/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2s-chef/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ospfunnum-base-chef
-Maintainer: Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 switch; Chef, PTM and OSPF Unnumbered IPv4
   2 switch lab, managed by Chef, OSPF Unnumbered IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-2s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-2s-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ospfunnum-base-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: 2 switch; Puppet, PTM and OSPF Unnumbered IPv4
   2 switch lab, managed by Puppet, OSPF Unnumbered IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-base-ansible/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-base-ansible/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base-ansible
-Maintainer: Nat Morris <nat@cumulusnetworks.com>, Stanley Karunditu <stanleyk@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Ansible, PTM and OSPF Unnumbered IPv4
   Ansible, OSPF Unnumbered IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-base-chef/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-base-chef/debian/DEBIAN/control
@@ -4,7 +4,7 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base-chef, cldemo-wbench-ztp-chef
-Maintainer: Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Chef, PTM and OSPF Unnumbered IPv4
   Chef, OSPF Unnumbered IPv4 and PTM
   Original Author Matt Willsher <mwillsher@cumulusnetworks.com>

--- a/pkgs/workbench/cldemo-wbench-ospfunnum-base-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ospfunnum-base-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Puppet, PTM and OSPF Unnumbered IPv4
   Puppet, OSPF Unnumbered IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-setup-standalone/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-setup-standalone/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Depends: ubuntu-standard, cldemo-wbench-base
 Architecture: all
-Maintainer: Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Pre-configures a fresh Ubuntu Server VM
     Installs dependencies such as Apache2, BIND9, ISC DHCPd

--- a/pkgs/workbench/cldemo-wbench-sflow-2lt22s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-sflow-2lt22s-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-sflow-base-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Setup sflow and ganglia web frontend 
   Setup the ganglia web front end and hsflowd on the switch to display monitoring examples

--- a/pkgs/workbench/cldemo-wbench-sflow-2s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-sflow-2s-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-sflow-base-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Setup sflow with 2s topology
   Setup hsflowd on the switch and display monitoring examples

--- a/pkgs/workbench/cldemo-wbench-sflow-base-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-sflow-base-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-sflow-base, cldemo-wbench-ospfunnum-base-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: sflow puppet base
   Setup hsflowd on the switch and display monitoring examples

--- a/pkgs/workbench/cldemo-wbench-sflow-base/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-sflow-base/debian/DEBIAN/control
@@ -5,6 +5,6 @@ Priority: optional
 Architecture: all
 Essential: no
 Depends: cldemo-wbench-base, openjdk-6-jre-headless, libapache2-mod-proxy-html
-Maintainer: Neil McKee [neil.mckee@inmon.com]
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: base files for demonstration of sFlow(R) monitoring agent
 Homepage: host-sflow.sourceforge.net

--- a/pkgs/workbench/cldemo-wbench-tftpd/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-tftpd/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: tftpd-hpa, ipmitool, cldemo-wbench-base
-Maintainer: Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: TFTP server dependency for OS installs
     TFTP server dependency for OS installs, sets up tftpd-hpa

--- a/pkgs/workbench/cldemo-wbench-vmware-2lt22s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-vmware-2lt22s-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-openvpn, cldemo-wbench-base-puppet, cldemo-wbench-osinstaller-vmwareesxi55, cldemo-wbench-ztp-puppet
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Vmware demo setup package for Puppet
   Tailored for the 2lt22s workbench setup

--- a/pkgs/workbench/cldemo-wbench-vxlanptp-2lt22s-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-vxlanptp-2lt22s-puppet/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-ospfunnum-base-puppet, cldemo-wbench-osinstaller-ubuntuserver-precise
-Maintainer: Leslie Carr <leslie@cumulusnetworks.com, Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: VXLAN PtP between 2 T2 leaf switches.
   4 switch lab, managed by Puppet, OSPF Unnumbered IPv4 and PTM

--- a/pkgs/workbench/cldemo-wbench-ztp-ansible/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ztp-ansible/debian/DEBIAN/control
@@ -3,6 +3,6 @@ Version: 0.4
 Section: base
 Priority: optional
 Architecture: all
-Maintainer: Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Zero touch provisioning script for Ansible
     Bootstrap zero touch provisioning script for Ansible

--- a/pkgs/workbench/cldemo-wbench-ztp-bash/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ztp-bash/debian/DEBIAN/control
@@ -3,6 +3,6 @@ Version: 0.1-1
 Section: base
 Priority: optional
 Architecture: all
-Maintainer: Nat Morris <nat@cumulusnetworks.com>, Leslie Carr <leslie@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Zero touch provisioning script for Bash
     Bootstrap zero touch provisioning script for Bash

--- a/pkgs/workbench/cldemo-wbench-ztp-chef/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ztp-chef/debian/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: cldemo-wbench-base-chef
-Maintainer: Matt Willsher <mwillsher@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Zero touch provisioning script for Chef
     Bootstrap zero touch provisioning script for Chef

--- a/pkgs/workbench/cldemo-wbench-ztp-puppet/debian/DEBIAN/control
+++ b/pkgs/workbench/cldemo-wbench-ztp-puppet/debian/DEBIAN/control
@@ -3,6 +3,6 @@ Version: 0.4-4
 Section: base
 Priority: optional
 Architecture: all
-Maintainer: Nat Morris <nat@cumulusnetworks.com>
+Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>
 Description: Zero touch provisioning script for Puppet
     Bootstrap zero touch provisioning script for Puppet


### PR DESCRIPTION
script that created this pull request.

```
#!/bin/bash

# put all files called "control" into a file list
filelist=`find -name "*control"`
homebase=`pwd`
new_maintainer='Maintainer: Customer Engineering <ce-ceng@cumulusnetworks.com>'
for entry in $filelist; do
  fullpath="${homebase}/${entry}"
  sed -i s/"Maintainer.*"/"$new_maintainer"/ $fullpath
done
```