### PR TITLE
Update cw-mux -add key bind for sync panes

### DIFF
--- a/pkgs/workbench/cldemo-wbench-base/debian/usr/local/cumulus/bin/cw-mux
+++ b/pkgs/workbench/cldemo-wbench-base/debian/usr/local/cumulus/bin/cw-mux
@@ -95,6 +95,9 @@ tmux bind-key C-p run 'tmux set-buffer CumulusLinux!; tmux paste-buffer'
 # ctrl-b ctrl-c = cumulus
 tmux bind-key C-c run 'tmux set-buffer cumulus; tmux paste-buffer'
 
+# ctrl-b ctrl-s synchronize window panes 
+tmux bind-key C-s set-window-option synchronize-panes
+
 # set up mouse
 if [[ $mouse == 1 ]]
 then


### PR DESCRIPTION
Added a shortcut ctrl-b ctrl-s to turn on/off sync panes