### PR TITLE
 fix cl_license call

### DIFF
--- a/pkgs/workbench/cldemo-wbench-base-ansible/debian/home/cumulus/ansibledemos/roles/common/tasks/main.yml
+++ b/pkgs/workbench/cldemo-wbench-base-ansible/debian/home/cumulus/ansibledemos/roles/common/tasks/main.yml
@@ -11,7 +11,8 @@
 - name: License switch
   cl_license: >
     src="http://{{ cl_license_server }}/{{ ansible_hostname }}.lic"
-    restart_switchd=yes
+  notify:
+    - restart switchd
 
 - name: configure ptmd topology.dot
   copy: src=topology.dot dest=/etc/ptm.d/topology.dot


### PR DESCRIPTION
cl_license now doesn't restart switchd in the module. starting in CL 2.5, switchd init script ensures that switchd has started completely before  exiting, so this fix applies to using ansible on CL 2.5 and higher.  Using cldemo's cl_license module in older CL versions may not work.